### PR TITLE
switch to setuptools version 2.0.1

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -76,7 +76,7 @@ except ImportError:
         from urllib2 import urlopen
 
     # XXX use a more permanent ez_setup.py URL when available.
-    exec(urlopen('https://bitbucket.org/pypa/setuptools/raw/0.7.2/ez_setup.py'
+    exec(urlopen('https://bitbucket.org/pypa/setuptools/raw/2.0.1/ez_setup.py'
                 ).read(), ez)
     setup_args = dict(to_dir=tmpeggs, download_delay=0)
     ez['use_setuptools'](**setup_args)


### PR DESCRIPTION
bei der nutzung von squid als http proxy tritt bei "älteren" setuptools-versionen zumindest unter debian folgender Fehler auf:
Download error on https://pypi.python.org/simple/: [Errno 1] _ssl.c:507: error:140770FC:SSL routines:SSL23_GET_SERVER_HELLO:unknown protocol -- Some packages may not be found!
^CTraceback (most recent call last):
  File "bootstrap.py", line 150, in <module>
    if subprocess.call(cmd, env=dict(os.environ, PYTHONPATH=setuptools_path)) != 0:
  File "/opt/python/2.7.6/lib/python2.7/subprocess.py", line 522, in call
    return Popen(_popenargs, *_kwargs).wait()
  File "/opt/python/2.7.6/lib/python2.7/subprocess.py", line 1375, in wait
    pid, sts = _eintr_retry_call(os.waitpid, self.pid, 0)
  File "/opt/python/2.7.6/lib/python2.7/subprocess.py", line 476, in _eintr_retry_call
    return func(*args)

Das Problem scheint mit setuptools 2.0.1 gelöst.
Das PRoblem  
